### PR TITLE
Removed broken DLL support

### DIFF
--- a/src/sw_base.h
+++ b/src/sw_base.h
@@ -37,7 +37,7 @@ bool sw_getVerboseMode(void);
 
 
 // Abstract base class for streaming sockets
-class DECLSPEC SWBaseSocket
+class SWBaseSocket
 {
 public:	
 	SWBaseSocket();
@@ -57,7 +57,7 @@ public:
 	// interrupted  - operation was interrupted by a nonblocked signal
 	enum base_error{ok, fatal, notReady, portInUse, notConnected, msgTooLong, terminated, noResponse, timeout, interrupted};
 	
-	class DECLSPEC SWBaseError
+	class SWBaseError
 	{
 	public:
 		SWBaseError();

--- a/src/sw_inet.h
+++ b/src/sw_inet.h
@@ -21,7 +21,7 @@
 #include <string>
 
 // Simple streaming TCP/IP class
-class DECLSPEC SWInetSocket : public SWBaseSocket
+class SWInetSocket : public SWBaseSocket
 {
 public:
 	SWInetSocket(block_type block=blocking);

--- a/src/sw_internal.h
+++ b/src/sw_internal.h
@@ -56,22 +56,6 @@ COMPILE_TIME_ASSERT(sint32, sizeof(Sint32) == 4);
 
 #endif /* _SDL_H */
 
-// Some compilers use a special export keyword
-#ifndef DECLSPEC
-  #ifdef __BEOS__
-    #if defined(__GNUC__)
-      #define DECLSPEC __declspec(dllexport)
-    #else
-      #define DECLSPEC __declspec(export)
-    #endif
-  #else
-    #ifdef _WIN32
-      #define DECLSPEC __declspec(dllexport)
-    #else
-      #define DECLSPEC
-    #endif
-  #endif
-#endif
 
 
 #endif /* sw_internal_H */

--- a/src/sw_ssl.h
+++ b/src/sw_ssl.h
@@ -33,7 +33,7 @@
 #define RSA_KEYEXP RSA_F4 /* 65537 */
 
 // Simple streaming SSL TCP/IP class
-class DECLSPEC SWSSLSocket : public SWInetSocket
+class SWSSLSocket : public SWInetSocket
 {
 public:
 	SWSSLSocket(block_type block=blocking, int keysize=RSA_KEYSIZE);
@@ -45,7 +45,7 @@ public:
 	// badFile      - Couldn't access or use file
 	enum ssl_error{noSSLError, badPasswd, badFile};
 	
-	class DECLSPEC SWSSLError : public SWBaseError
+	class SWSSLError : public SWBaseError
 	{
 	public:
 		SWSSLError();

--- a/src/sw_unix.h
+++ b/src/sw_unix.h
@@ -22,7 +22,7 @@
 #include <string>
 
 // Simple streaming Unix class
-class DECLSPEC SWUnixSocket : public SWBaseSocket
+class SWUnixSocket : public SWBaseSocket
 {
 public:
 	SWUnixSocket(block_type block=blocking);


### PR DESCRIPTION
SocketW uses a `std::string` in it's public interface, which makes it unsuitable for DLL export.

Visual Studio 2015 detects this and prints "needs to have dll-interface..." warnings for each compilation unit which #include-s SocketW.

See https://stackoverflow.com/questions/23612458/can-a-stdstring-be-passed-by-value-across-dll-boundries