### PR TITLE
:bug: Fixed error handling when running multithreaded

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-openssl/1.1.1g
+openssl/1.1.1m
 
 [generators]
 cmake_find_package

--- a/src/sw_base.cxx
+++ b/src/sw_base.cxx
@@ -94,26 +94,15 @@ void WSA_exit(void)
 //== Error handling mode
 //====================================================================
 bool sw_DoThrow = false;
-bool sw_Verbose = true;
 
 void sw_setThrowMode(bool throw_errors)
 {
 	sw_DoThrow = throw_errors;
 }
 
-void sw_setVerboseMode(bool verbose)
-{
-	sw_Verbose = verbose;
-}
-
 bool sw_getThrowMode(void)
 {
 	return sw_DoThrow;
-}
-
-bool sw_getVerboseMode(void)
-{
-	return sw_Verbose;
 }
 
 
@@ -176,7 +165,6 @@ SWBaseSocket::SWBaseSocket()
 	recv_close = false;	
 	
 	//init values
-	error_string = "";
 	block_mode = blocking;
 	fsend_ready = true;
 	frecv_ready = true;
@@ -290,7 +278,9 @@ bool SWBaseSocket::disconnect(SWBaseError *error)
 	}
 
 	if( n != 0 ){
-		set_error(error, err, error_string);
+		char err_str[100];
+		snprintf(err_str, 100, "SWBaseSocket::disconnect() - recv() failed with code %d", n);
+		set_error(error, err, err_str);
 		return false; //error
 	}
 	
@@ -631,12 +621,6 @@ bool SWBaseSocket::waitWrite(SWBaseError *error)
 	return waitIO(tmp, error);
 }
 
-void SWBaseSocket::print_error()
-{
-	if( error_string.size() > 0 )
-		fprintf(stderr, "%s!\n", error_string.c_str());
-}
-
 void SWBaseSocket::handle_errno(SWBaseError *error, string msg)
 {
 	#ifndef _WIN32
@@ -743,24 +727,16 @@ void SWBaseSocket::no_error(SWBaseError *error)
 
 void SWBaseSocket::set_error(SWBaseError *error, SWBaseError name, string msg)
 {
-	error_string = msg;
-
-	if(error != NULL){
+	if( sw_DoThrow ){
+		SWBaseError e;
+		e = name;
+		e.error_string = msg;
+		e.failed_class = this;
+		throw e;
+	} else if(error != NULL){
 		*error = name;
 		error->error_string = msg;
 		error->failed_class = this;
-	}else{
-		if( sw_Verbose )
-			print_error();
-		
-		if( sw_DoThrow ){
-			SWBaseError e;
-			e = name;
-			e.error_string = msg;
-			e.failed_class = this;
-			throw e;
-		}else
-			exit(-1);	
 	}
 }
 

--- a/src/sw_base.h
+++ b/src/sw_base.h
@@ -31,9 +31,7 @@
 //
 // Default is throw_errors == false and verbose == true
 void sw_setThrowMode(bool throw_errors);
-void sw_setVerboseMode(bool verbose);
 bool sw_getThrowMode(void);
-bool sw_getVerboseMode(void);
 
 
 // Abstract base class for streaming sockets
@@ -152,10 +150,6 @@ public:
 	// and others that use those, i.e. all frecvmsg().
 	void set_timeout(Uint32 sec, Uint32 usec){ tsec = sec, tusec = usec; }
 	
-	// Error handling
-	virtual void print_error(); //prints the last error if any to stderr
-	virtual std::string get_error(){return error_string;}  //returns a human readable error string
-
 protected:
 	// get a new socket if myfd < 0
 	virtual void get_socket()=0;
@@ -179,9 +173,6 @@ protected:
 
 	// our socket descriptor
 	int myfd;
-	
-	// last error
-	std::string error_string;
 
 	// data for fsend
 	bool fsend_ready;

--- a/src/sw_ssl.cxx
+++ b/src/sw_ssl.cxx
@@ -911,7 +911,7 @@ int SWSSLSocket::recv(char *buf, int bytes, SWBaseError *error)
 	return ret;
 }
 
-extern bool sw_DoThrow, sw_Verbose; // Defined in sw_base.cxx
+extern bool sw_DoThrow; // Defined in sw_base.cxx
 void SWSSLSocket::set_SSLError(SWBaseError *error, SWSSLError name, string msg)
 {
 	// Can this be handled by the standard error handling?
@@ -920,36 +920,27 @@ void SWSSLSocket::set_SSLError(SWBaseError *error, SWSSLError name, string msg)
 		set_error(error, name.be, msg);
 		return;
 	}
-	
-	error_string = msg;
 
-	if(error != NULL){
-		SWSSLError *err;
-		
-		if( (err = dynamic_cast<SWSSLError*>(error)) ){
-			// Ok, "error" is a SWSSLError class, we can set the SSL specific error
-			err->be = name.be;
-			err->se = name.se;
-			err->error_string = msg;
-			err->failed_class = this;
-		} else {
-			// Standard error handling (must be handled by SWBaseSocket::set_error())
-			set_error(error, name.be, msg);
-		}
-	}else{
-		if( sw_Verbose )
-			print_error();
-		
-		if( sw_DoThrow ){
-			SWSSLError e;
-			e.be = name.be;
-			e.se = name.se;
-			e.error_string = msg;
-			e.failed_class = this;
-			throw e;
-		}else
-			exit(-1);	
-	}
+        if( sw_DoThrow ){
+		SWSSLError e;
+                e = name;
+                e.error_string = msg;
+                e.failed_class = this;
+                throw e;
+        } else if(error != NULL){
+                SWSSLError *err;
+
+                if( (err = dynamic_cast<SWSSLError*>(error)) ){
+                        // Ok, "error" is a SWSSLError class, we can set the SSL specific error
+                        err->be = name.be;
+                        err->se = name.se;
+                        err->error_string = msg;
+                        err->failed_class = this;
+                } else {
+                        // Standard error handling (must be handled by SWBaseSocket::set_error())
+                        set_error(error, name.be, msg);
+                }
+        }
 }
 
 void SWSSLSocket::handle_ERRerror(SWBaseError *error, SWSSLError name, string msg)


### PR DESCRIPTION
Patch applied from https://github.com/RigsOfRods/ror-server/commit/b455cec7a69745b7c854c4d701556a2e57d8a615

> Removed variable `SWBaseSocket::error_string` which was written on any error and read on error in `disconnect()`, all without synchronization. This is a problem in Rigs of Rods server which uses each client socket from 2 threads: receiver and broadcaster.
Function `SWBaseSocket::set_error()` was modified to only fill the supplied SWBaseError object, without touching anything in the SWBaseSocket object. Also, the function won't shut down the whole program with `exit()` anymore.
"verbose mode" was removed completely.